### PR TITLE
Adding support for ${workspaceFolder} in docker paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Running tests in already running Docker containers:
 }
 ```
 
+> You can use `${workspaceFolder}` in your local paths to define a wildcard for the currently open workspace. 
+
 Running tests with Docker Compose, starting up a service and removing the container when finished:
 ```
 {

--- a/src/docker-pest-command.js
+++ b/src/docker-pest-command.js
@@ -3,7 +3,11 @@ const RemotePestCommand = require('./remote-pest-command');
 
 module.exports = class DockerPestCommand extends RemotePestCommand {
     get paths() {
-        return this.config.get("docker.paths");
+        let paths = {}; 
+        for (const [localPath, remotePath] of Object.entries(this.config.get("docker.paths"))) {
+            paths[ localPath.replace('${workspaceRoot}', vscode.workspace.rootPath) ] = remotePath; 
+        }
+        return paths;
     }
 
     get dockerCommand() {

--- a/src/docker-pest-command.js
+++ b/src/docker-pest-command.js
@@ -5,7 +5,7 @@ module.exports = class DockerPestCommand extends RemotePestCommand {
     get paths() {
         let paths = {}; 
         for (const [localPath, remotePath] of Object.entries(this.config.get("docker.paths"))) {
-            paths[ localPath.replace('${workspaceRoot}', vscode.workspace.rootPath) ] = remotePath; 
+            paths[ localPath.replace('${workspaceFolder}', vscode.workspace.rootPath) ] = remotePath; 
         }
         return paths;
     }


### PR DESCRIPTION
I did this because most of the time I need to have a wildcard to define the root directory of the project in global settings, so I can sync settings among different computers and setup without losing the functionality. 

This way, we can use the `${workspaceFolder}` wildcard to define the root of the project. 

```json 
{
    "better-pest.docker.command": "lando php",
    "better-pest.docker.enable": true,
    "better-pest.docker.paths": {
        "${workspaceFolder}": "."
    }
}
```
So now my tests run using `./vendor/bin/pest` within the docker container, and they always use the same route regardless of the computer home directory or the setup. (I use both macOS and Linux). 


_Ignore the Lando line, it's just the environment I use, but you can consider the same scenario for docker._