### PR TITLE
Remove unnecessary 'get' from the regex match

### DIFF
--- a/src/pest-command.js
+++ b/src/pest-command.js
@@ -89,7 +89,7 @@ module.exports = class PestCommand {
 
         while (line > 0) {
             const lineText = vscode.window.activeTextEditor.document.lineAt(line).text;
-            const match = lineText.match(/^\s*(?:it|test|get)\(([^,)]+)/m);
+            const match = lineText.match(/^\s*(?:it|test)\(([^,)]+)/m);
             if (match) {
                 method = match[1];
                 break;


### PR DESCRIPTION
Fixes #8 

Not sure why the `get` keyword was being matched for.

Pest only has `it()` and `test()`
https://pestphp.com/docs/writing-tests